### PR TITLE
release: latest version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -94,7 +94,7 @@ jobs:
             name: python-package-distributions
             path: dist/
         - name: Publish distribution 📦 to PyPI
-          uses: pypa/gh-action-pypi-publish@release/v1
+          uses: pypa/gh-action-pypi-publish@release/v1.12
 
     github-release:
         name: >-
@@ -115,7 +115,7 @@ jobs:
             name: python-package-distributions
             path: dist/
         - name: Sign the dists with Sigstore
-          uses: sigstore/gh-action-sigstore-python@v2.1.1
+          uses: sigstore/gh-action-sigstore-python@v3.0.0
           with:
             inputs: >-
                 ./dist/*.tar.gz


### PR DESCRIPTION
Update the GH actions to fix the broken publishing pipeline for PyPI signing.